### PR TITLE
pyproject.toml: Define a version constraint maturin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["maturin"]
+requires = ["maturin >= 0.11"]
 build-backend = "maturin"


### PR DESCRIPTION
Will be required in the future, see PyO3/maturin#545.

Noticed it by this warning in the CI:
```
⚠️  Warning: Please use maturin in pyproject.toml with a version constraint, e.g. `requires = ["maturin>=0.11,<0.12"]`. This will become an error.
```