### PR TITLE
CI: Build universal macOS binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install maturin
+    - name: Install aarch64-apple-darwin toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: aarch64-apple-darwin
     - name: Do the work mate
-      run: maturin publish -i python --no-sdist -u hledoux -p ${{ secrets.PASSWORD_PYPI }}
+      run: maturin publish -i python --no-sdist --universal2 -u hledoux -p ${{ secrets.PASSWORD_PYPI }}
 
   Linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,64 +5,57 @@ on:
   types: [created]
 
 jobs:
-
   Windows:
     runs-on: windows-latest
     strategy:
-      max-parallel: 4
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install maturin
       run: |
         python -m pip install --upgrade pip
         pip install maturin
     - name: Do the work mate
-      run: |
-        maturin publish -i python --no-sdist -u hledoux -p ${{ secrets.PASSWORD_PYPI }}
+      run: maturin publish -i python --no-sdist -u hledoux -p ${{ secrets.PASSWORD_PYPI }}
 
-  MacOS:
+  macOS:
     runs-on: macos-latest
     strategy:
-      max-parallel: 4
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install maturin
       run: |
         python -m pip install --upgrade pip
         pip install maturin
     - name: Do the work mate
-      run: |
-        maturin publish -i python --no-sdist -u hledoux -p ${{ secrets.PASSWORD_PYPI }}
+      run: maturin publish -i python --no-sdist -u hledoux -p ${{ secrets.PASSWORD_PYPI }}
 
   Linux:
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux_2_24_x86_64
     strategy:
-      max-parallel: 4
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install maturin
       run: |
         python -m pip install --upgrade pip
         pip install maturin
     - name: Do the work mate
-      run: |
-        maturin publish -i python -u hledoux -p ${{ secrets.PASSWORD_PYPI }}
+      run: maturin publish -i python -u hledoux -p ${{ secrets.PASSWORD_PYPI }}


### PR DESCRIPTION
First commit, some clean-up:
- Remove whitelines
- Remove redundant max-parallel parameter
- Remove pip upgrade pip, pip is very recent already on GitHub Actions
- Update to [actions/checkout](https://github.com/actions/checkout)@v2 and [actions/setup-python](https://github.com/actions/setup-python)@v2
- Inline single-line `run:` commands

Second commit, build universal macOS binaries:
 - Install the toolchain for the `aarch64-apple-darwin` target
 - Pass `--universal2` to create universal macOS binaries that work on both x86-64 and aarch64 CPUs

I did a [test run](https://github.com/EwoutH/startinpy/actions/runs/1436296063) here. Maybe we should setup a workflow running `maturin build --release` for each push and pull request? This way we won't be surprised if something breaks on release.