### PR TITLE
Add lazrs to dt_comparisons/requirements.txt

### DIFF
--- a/dt_comparisons/requirements.txt
+++ b/dt_comparisons/requirements.txt
@@ -5,6 +5,7 @@ click==8.1.7
 click-plugins==1.1.1
 cligj==0.7.2
 laspy==2.5.4
+lazrs==0.6.1
 numpy==2.1.0
 pdal==3.4.5
 py-markdown-table==1.1.0


### PR DESCRIPTION
Fix a `laspy.errors.LaspyException` error when running `laspy.read()` in the `dt_comparisons/comparisons.py` script. Assuming that we want the `lazrs` [backend](https://laspy.readthedocs.io/en/latest/installation.html#optional-dependencies-features) instead of `laszip-python` :wink:

Full traceback error was:

```
Traceback (most recent call last):
  File "/home/user/projects/startinpy/dt_comparisons/comparisons.py", line 318, in <module>
    t_startinpy()
  File "/home/user/projects/startinpy/dt_comparisons/comparisons.py", line 158, in t_startinpy
    las = laspy.read(path_laz_2m)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/mambaforge/envs/startin/lib/python3.12/site-packages/laspy/lib.py", line 255, in read_las
    return reader.read()
           ^^^^^^^^^^^^^
  File "/home/user/mambaforge/envs/startin/lib/python3.12/site-packages/laspy/lasreader.py", line 126, in read
    points = self.read_points(-1)
             ^^^^^^^^^^^^^^^^^^^^
  File "/home/user/mambaforge/envs/startin/lib/python3.12/site-packages/laspy/lasreader.py", line 107, in read_points
    self.point_source.read_n_points(n), self.header.point_format
    ^^^^^^^^^^^^^^^^^
  File "/home/user/mambaforge/envs/startin/lib/python3.12/site-packages/laspy/lasreader.py", line 75, in point_source
    self._point_source = self._create_point_source(self._source)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/mambaforge/envs/startin/lib/python3.12/site-packages/laspy/lasreader.py", line 291, in _create_point_source
    point_source = self._create_laz_backend(source)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/mambaforge/envs/startin/lib/python3.12/site-packages/laspy/lasreader.py", line 259, in _create_laz_backend
    raise errors.LaspyException(
laspy.errors.LaspyException: No LazBackend selected, cannot decompress data
```

